### PR TITLE
Ray changes

### DIFF
--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -55,7 +55,7 @@ contract Web3Atl is ERC721, Ownable {
     function hackerMint(bytes32[] calldata _hackerProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
         require(
-            MerkleProofLib.verify(_hackerProof, leaf, hackerMerkleRoot),
+            MerkleProofLib.verify(_hackerProof, hackerMerkleRoot, leaf),
             "You are not a hacker"
         );
         require(!hackerClaimed[msg.sender], "You already claimed your token");
@@ -71,7 +71,7 @@ contract Web3Atl is ERC721, Ownable {
     function generalMint(bytes32[] calldata _generalProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
         require(
-            MerkleProofLib.verify(_generalProof, leaf, generalMerkleRoot),
+            MerkleProofLib.verify(_generalProof, generalMerkleRoot, leaf),
             "You are not a general attendee"
         );
         require(!generalClaimed[msg.sender], "You already claimed your token");
@@ -87,7 +87,7 @@ contract Web3Atl is ERC721, Ownable {
     function teamMint(bytes32[] calldata _teamProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
         require(
-            MerkleProofLib.verify(_teamProof, leaf, teamMerkleRoot),
+            MerkleProofLib.verify(_teamProof, teamMerkleRoot, leaf),
             "You are not a team member"
         );
         require(!teamClaimed[msg.sender], "You already claimed your token");
@@ -103,7 +103,7 @@ contract Web3Atl is ERC721, Ownable {
     function speakerMint(bytes32[] calldata _speakerProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
         require(
-            MerkleProofLib.verify(_speakerProof, leaf, speakerMerkleRoot),
+            MerkleProofLib.verify(_speakerProof, speakerMerkleRoot, leaf),
             "You are not a speaker"
         );
         require(!speakerClaimed[msg.sender], "You already claimed your token");

--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -153,8 +153,6 @@ contract Web3Atl is ERC721, Ownable {
                 baseURI,
                 "/",
                 Strings.toString(uint256(tokenType[id])),
-                "/",
-                Strings.toString(id),
                 ".json"
             );
     }

--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -25,7 +25,7 @@ contract Web3Atl is ERC721, Ownable {
     bytes32 public speakerMerkleRoot;
 
     // instantiate attendee type for a tokenID. Used to set uri's.
-    mapping(uint256 => AttendeeTypes) tokenType;
+    mapping(uint256 => AttendeeTypes) public tokenType;
 
     // instantiate owner for a tokenID
     mapping(uint256 => address) public tokenOwner;

--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -7,18 +7,17 @@ import "openzeppelin-contracts/utils/Strings.sol";
 import "openzeppelin-contracts/access/Ownable.sol";
 import "solmate/utils/MerkleProofLib.sol";
 
-
 contract Web3Atl is ERC721, Ownable {
     uint256 public tokenID;
     string public baseURI;
 
     enum AttendeeTypes {
-        HACKER, 
-        GENERAL, 
-        TEAM, 
+        HACKER,
+        GENERAL,
+        TEAM,
         SPEAKER
     }
-    
+
     // instantiate merkle roots for all attendee types
     bytes32 public hackerMerkleRoot;
     bytes32 public generalMerkleRoot;
@@ -37,17 +36,28 @@ contract Web3Atl is ERC721, Ownable {
     mapping(address => bool) public teamClaimed;
     mapping(address => bool) public speakerClaimed;
 
-
-    constructor(string memory _name, string memory _symbol) ERC721(_name, _symbol) {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        string memory _baseURI,
+        bytes32 _hackerMerkleRoot,
+        bytes32 _generalMerkleRoot,
+        bytes32 _teamMerkleRoot,
+        bytes32 _speakerMerkleRoot
+    ) ERC721(_name, _symbol) {
         tokenID = 0;
-        baseURI = "";
+        baseURI = _baseURI;
+        _setMerkleRoots(_hackerMerkleRoot, _generalMerkleRoot, _teamMerkleRoot, _speakerMerkleRoot);
     }
 
     /// @notice mint function for hackathon participants
     /// @param _hackerProof merkle tree proof
-    function hackerMint(bytes32[] calldata  _hackerProof) public {
+    function hackerMint(bytes32[] calldata _hackerProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-        require(MerkleProofLib.verify(_hackerProof, leaf, hackerMerkleRoot), "You are not a hacker");
+        require(
+            MerkleProofLib.verify(_hackerProof, leaf, hackerMerkleRoot),
+            "You are not a hacker"
+        );
         require(!hackerClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -60,7 +70,10 @@ contract Web3Atl is ERC721, Ownable {
     /// @param _generalProof merkle tree proof
     function generalMint(bytes32[] calldata _generalProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-        require(MerkleProofLib.verify(_generalProof, leaf, generalMerkleRoot), "You are not a general attendee");
+        require(
+            MerkleProofLib.verify(_generalProof, leaf, generalMerkleRoot),
+            "You are not a general attendee"
+        );
         require(!generalClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -73,7 +86,10 @@ contract Web3Atl is ERC721, Ownable {
     /// @param _teamProof merkle tree proof
     function teamMint(bytes32[] calldata _teamProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-        require(MerkleProofLib.verify(_teamProof, leaf, teamMerkleRoot), "You are not a team member");
+        require(
+            MerkleProofLib.verify(_teamProof, leaf, teamMerkleRoot),
+            "You are not a team member"
+        );
         require(!teamClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -86,7 +102,10 @@ contract Web3Atl is ERC721, Ownable {
     /// @param _speakerProof merkle tree proof
     function speakerMint(bytes32[] calldata _speakerProof) public {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-        require(MerkleProofLib.verify(_speakerProof, leaf, speakerMerkleRoot), "You are not a speaker");
+        require(
+            MerkleProofLib.verify(_speakerProof, leaf, speakerMerkleRoot),
+            "You are not a speaker"
+        );
         require(!speakerClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -96,16 +115,26 @@ contract Web3Atl is ERC721, Ownable {
     }
 
     /// @notice sets the merkle roots for all attendee types
-    function setMerkleRoots(
-        bytes32 _hackerMerkleRoot, 
-        bytes32 _generalMerkleRoot, 
-        bytes32 _teamMerkleRoot, 
-        bytes32 _speakerMerkleRoot) external onlyOwner {
-
+    function _setMerkleRoots(
+        bytes32 _hackerMerkleRoot,
+        bytes32 _generalMerkleRoot,
+        bytes32 _teamMerkleRoot,
+        bytes32 _speakerMerkleRoot
+    ) private {
         hackerMerkleRoot = _hackerMerkleRoot;
         generalMerkleRoot = _generalMerkleRoot;
         teamMerkleRoot = _teamMerkleRoot;
         speakerMerkleRoot = _speakerMerkleRoot;
+    }
+
+    /// @notice sets the merkle roots for all attendee types
+    function setMerkleRoots(
+        bytes32 _hackerMerkleRoot,
+        bytes32 _generalMerkleRoot,
+        bytes32 _teamMerkleRoot,
+        bytes32 _speakerMerkleRoot
+    ) external onlyOwner {
+        _setMerkleRoots(_hackerMerkleRoot, _generalMerkleRoot, _teamMerkleRoot, _speakerMerkleRoot);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -114,26 +143,32 @@ contract Web3Atl is ERC721, Ownable {
 
     /// @notice sets the base uri
     /// @param _uri new string with the format ipfs://gateaway
-    function setURI(string memory _uri) external onlyOwner {
+    function setBaseURI(string memory _uri) external onlyOwner {
         baseURI = _uri;
     }
 
     function tokenURI(uint256 id) public view override returns (string memory) {
-        return string.concat(baseURI, "/", Strings.toString(uint(tokenType[id])), "/", Strings.toString(id), ".json");
+        return
+            string.concat(
+                baseURI,
+                "/",
+                Strings.toString(uint256(tokenType[id])),
+                "/",
+                Strings.toString(id),
+                ".json"
+            );
     }
-
 
     ////////////////////////////////////////////////////////////////////////////
     ///////////////////// OVERRIDE TRANSFERS ///////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
 
-    
     function transferFrom(
         address from,
         address to,
         uint256 id
     ) public override {
-        revert('This token cant be transfered');
+        revert("This token cant be transfered");
     }
 
     function safeTransferFrom(
@@ -141,7 +176,7 @@ contract Web3Atl is ERC721, Ownable {
         address to,
         uint256 id
     ) public override {
-        revert('This token cant be transfered');
+        revert("This token cant be transfered");
     }
 
     function safeTransferFrom(
@@ -150,6 +185,6 @@ contract Web3Atl is ERC721, Ownable {
         uint256 id,
         bytes calldata data
     ) public override {
-        revert('This token cant be transfered');
+        revert("This token cant be transfered");
     }
 }

--- a/test/Web3Atl.t.sol
+++ b/test/Web3Atl.t.sol
@@ -1,14 +1,237 @@
-// // SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
+import "forge-std/console.sol";
 import "../src/Web3Atl.sol";
+import "solmate/utils/MerkleProofLib.sol";
 
 contract Web3AtlTest is Test {
     Web3Atl public web3atl;
+    string public baseURI = "http://www.google.com/";
+    
+    bytes32 merkleRootHacker = 0xb4fbf216f54d8076e21c170049082954cc613623e76fb5aab2acce1daeae683a;
+    bytes32 merkleRootGeneral = 0x4d3fcb52d31462529df063f8a5bd68dcca0642f9eb1c686676c8f79b8f3b2e81;
+    bytes32 merkleRootTeam = 0x1fa1b44ca84213104080ce844322b0ed53acb13304413773f6f3b23d34fbd434;
+    bytes32 merkleRootSpeaker = 0x91b8f47511578845af7aa2a841fa49dfefe81f5fa7180a9579af282f94610d44;
 
     function setUp() public {
-        web3atl = new Web3Atl('Web3Atl Attendees','W3ATL');
+        web3atl = new Web3Atl('Web3Atl Attendees','W3ATL', baseURI, merkleRootHacker, merkleRootGeneral, merkleRootTeam, merkleRootSpeaker);
     }
 
+    function testBaseURIAfterSetUp() public {
+        assertEq(web3atl.baseURI(), baseURI);
+    }
+
+    function testSetBaseURI(string memory newBaseURI) public {
+        web3atl.setBaseURI(newBaseURI);
+        assertEq(web3atl.baseURI(), newBaseURI);
+    }
+
+    function testSetBaseURINotOwner(address addr, string memory newBaseURI) public {
+        vm.prank(addr);
+        vm.expectRevert();
+        web3atl.setBaseURI(newBaseURI);
+    }
+
+    function testHackerMintValidAddressAndProof() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+        
+        assertEq(web3atl.tokenOwner(tokenID), hackerAddress);
+        assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.HACKER);
+        assert(web3atl.hackerClaimed(hackerAddress));
+        
+        uint256 newTokenID = web3atl.tokenID();
+        assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testHackerMintInvalidAddressAndProof(bytes32[] memory proof) public {
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        vm.expectRevert();
+        web3atl.hackerMint(proof);
+    }
+
+    function testGeneralMintValidAddressAndProof() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x3aa681f45a864d97845dc2341b9aa2ca3ad6f4c512b6a324caf7625fe6e17ba4;
+        proof[1] = 0x3c2715b13dbf00e2e7599f4db973e15c5f22ccde8b5fbb56363b47b7b3c19307;
+        proof[2] = 0xde127622dbe22a3b21641fc6d27aaa4d4cae7cc5dd5287a81f2352d272b28d60;
+        proof[3] = 0x3361b6655670e8cd9453722e2beb88101d9f6f821620e0f051aa5fed75273aa1;
+        
+        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
+        vm.prank(generalAddress);
+        web3atl.generalMint(proof);
+        
+        assertEq(web3atl.tokenOwner(tokenID), generalAddress);
+        assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.GENERAL);
+        assert(web3atl.generalClaimed(generalAddress));
+        
+        uint256 newTokenID = web3atl.tokenID();
+        assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testGeneralMintInvalidAddressAndProof(bytes32[] memory proof) public {
+        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
+        vm.prank(generalAddress);
+        vm.expectRevert();
+        web3atl.generalMint(proof);
+    }
+    
+    function testTeamMintValidAddressAndProof() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0xad8c33e774d72922c432a84b04cd50002dc4fd8132f2c15026badc9af139a78a;
+        proof[1] = 0x51e301f9a1a65b6bfdc6dde3abf457c998378a4c171654b8f6f4a52d921e6ba5;
+        proof[2] = 0x258f6d28136116795a2538071df3d61c3d291eb705e4cf54b559f08980a93c44;
+        proof[3] = 0x28572302ba5c6b91c6ef2a49e675f5648b0e83483903863cf7fd9f4202d0e384;
+        
+        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
+        vm.prank(teamAddress);
+        web3atl.teamMint(proof);
+        
+        assertEq(web3atl.tokenOwner(tokenID), teamAddress);
+        assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.TEAM);
+        assert(web3atl.teamClaimed(teamAddress));
+        
+        uint256 newTokenID = web3atl.tokenID();
+        assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testTeamMintInvalidAddressAndProof(bytes32[] memory proof) public {
+        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
+        vm.prank(teamAddress);
+        vm.expectRevert();
+        web3atl.teamMint(proof);
+    }
+
+    function testSpeakerMintValidAddressAndProof() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0xbc4604c224b8f02a5cb121b11860cac16d460942971558d99c3b28151ff6195c;
+        proof[1] = 0x7a03abb19f5b606aeabe37c940010ed150ce0c9d1080c847bcba06652be93d20;
+        proof[2] = 0x4c3840bc5d26b526b7859a60563e28bbeb901d087803855af0aaf00556744838;
+        proof[3] = 0x948c4f23df5e9ed19debfbb6f9493ba7a2b8cf747862149cbb4334cebb735b35;
+        
+        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
+        vm.prank(speakerAddress);
+        web3atl.speakerMint(proof);
+        
+        assertEq(web3atl.tokenOwner(tokenID), speakerAddress);
+        assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.SPEAKER);
+        assert(web3atl.speakerClaimed(speakerAddress));
+        
+        uint256 newTokenID = web3atl.tokenID();
+        assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testSpeakerMintInvalidAddressAndProof(bytes32[] memory proof) public {
+        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
+        vm.prank(speakerAddress);
+        vm.expectRevert();
+        web3atl.speakerMint(proof);
+    }
+
+    function testSetMerkleRoot(bytes32 newMerkleRootHacker, bytes32 newMerkleRootGeneral, bytes32 newMerkleRootTeam, bytes32 newMerkleRootSpeaker) public {
+        web3atl.setMerkleRoots(newMerkleRootHacker, newMerkleRootGeneral, newMerkleRootTeam, newMerkleRootSpeaker);
+
+        assertEq(web3atl.hackerMerkleRoot(), newMerkleRootHacker);
+        assertEq(web3atl.generalMerkleRoot(), newMerkleRootGeneral);
+        assertEq(web3atl.teamMerkleRoot(), newMerkleRootTeam);
+        assertEq(web3atl.speakerMerkleRoot(), newMerkleRootSpeaker);
+    }
+
+    function testSetMerkleRootNotOwner(address addr, bytes32 newMerkleRootHacker, bytes32 newMerkleRootGeneral, bytes32 newMerkleRootTeam, bytes32 newMerkleRootSpeaker) public {
+        vm.prank(addr);
+        vm.expectRevert();
+        web3atl.setMerkleRoots(newMerkleRootHacker, newMerkleRootGeneral, newMerkleRootTeam, newMerkleRootSpeaker);
+    }
+
+    function testTokenURI() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+        
+        assertEq(web3atl.tokenURI(tokenID), string.concat(
+                baseURI,
+                "/",
+                Strings.toString(uint256(web3atl.tokenType(tokenID))),
+                "/",
+                Strings.toString(tokenID),
+                ".json"
+            ));
+    }
+
+    function testTransferFrom() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+
+        vm.expectRevert();
+        web3atl.transferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
+    }
+
+    function testSafeTransferFrom() public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+
+        vm.expectRevert();
+        web3atl.safeTransferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
+    }
+
+    function testSafeTransferFromWithCallData(bytes calldata data) public {
+        uint256 tokenID = web3atl.tokenID();
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+
+        vm.expectRevert();
+        web3atl.safeTransferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID, data);
+    }
 }

--- a/test/Web3Atl.t.sol
+++ b/test/Web3Atl.t.sol
@@ -8,7 +8,7 @@ import "solmate/utils/MerkleProofLib.sol";
 
 contract Web3AtlTest is Test {
     Web3Atl public web3atl;
-    string public baseURI = "http://www.google.com/";
+    string public baseURI = "http://www.google.com";
     
     bytes32 merkleRootHacker = 0xb4fbf216f54d8076e21c170049082954cc613623e76fb5aab2acce1daeae683a;
     bytes32 merkleRootGeneral = 0x4d3fcb52d31462529df063f8a5bd68dcca0642f9eb1c686676c8f79b8f3b2e81;
@@ -55,6 +55,22 @@ contract Web3AtlTest is Test {
         assertEq(newTokenID - 1, tokenID);
     }
 
+    function testHackerCannotMintTwice() public {
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
+        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
+        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
+        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        
+        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
+        vm.prank(hackerAddress);
+        web3atl.hackerMint(proof);
+        
+        vm.prank(hackerAddress);
+        vm.expectRevert();
+        web3atl.hackerMint(proof);
+    }
+
     function testHackerMintInvalidAddressAndProof(bytes32[] memory proof) public {
         address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
         vm.prank(hackerAddress);
@@ -81,6 +97,22 @@ contract Web3AtlTest is Test {
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testGeneralCannotMintTwice() public {
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0x3aa681f45a864d97845dc2341b9aa2ca3ad6f4c512b6a324caf7625fe6e17ba4;
+        proof[1] = 0x3c2715b13dbf00e2e7599f4db973e15c5f22ccde8b5fbb56363b47b7b3c19307;
+        proof[2] = 0xde127622dbe22a3b21641fc6d27aaa4d4cae7cc5dd5287a81f2352d272b28d60;
+        proof[3] = 0x3361b6655670e8cd9453722e2beb88101d9f6f821620e0f051aa5fed75273aa1;
+        
+        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
+        vm.prank(generalAddress);
+        web3atl.generalMint(proof);
+        
+        vm.prank(generalAddress);
+        vm.expectRevert();
+        web3atl.generalMint(proof);
     }
 
     function testGeneralMintInvalidAddressAndProof(bytes32[] memory proof) public {
@@ -111,6 +143,22 @@ contract Web3AtlTest is Test {
         assertEq(newTokenID - 1, tokenID);
     }
 
+    function testTeamCannotMintTwice() public {
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0xad8c33e774d72922c432a84b04cd50002dc4fd8132f2c15026badc9af139a78a;
+        proof[1] = 0x51e301f9a1a65b6bfdc6dde3abf457c998378a4c171654b8f6f4a52d921e6ba5;
+        proof[2] = 0x258f6d28136116795a2538071df3d61c3d291eb705e4cf54b559f08980a93c44;
+        proof[3] = 0x28572302ba5c6b91c6ef2a49e675f5648b0e83483903863cf7fd9f4202d0e384;
+        
+        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
+        vm.prank(teamAddress);
+        web3atl.teamMint(proof);
+        
+        vm.prank(teamAddress);
+        vm.expectRevert();
+        web3atl.teamMint(proof);
+    }
+
     function testTeamMintInvalidAddressAndProof(bytes32[] memory proof) public {
         address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
         vm.prank(teamAddress);
@@ -137,6 +185,22 @@ contract Web3AtlTest is Test {
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
+    }
+
+    function testSpeakerCannotMintTwice() public {
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = 0xbc4604c224b8f02a5cb121b11860cac16d460942971558d99c3b28151ff6195c;
+        proof[1] = 0x7a03abb19f5b606aeabe37c940010ed150ce0c9d1080c847bcba06652be93d20;
+        proof[2] = 0x4c3840bc5d26b526b7859a60563e28bbeb901d087803855af0aaf00556744838;
+        proof[3] = 0x948c4f23df5e9ed19debfbb6f9493ba7a2b8cf747862149cbb4334cebb735b35;
+        
+        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
+        vm.prank(speakerAddress);
+        web3atl.speakerMint(proof);
+        
+        vm.prank(speakerAddress);
+        vm.expectRevert();
+        web3atl.speakerMint(proof);
     }
 
     function testSpeakerMintInvalidAddressAndProof(bytes32[] memory proof) public {
@@ -178,8 +242,6 @@ contract Web3AtlTest is Test {
                 baseURI,
                 "/",
                 Strings.toString(uint256(web3atl.tokenType(tokenID))),
-                "/",
-                Strings.toString(tokenID),
                 ".json"
             ));
     }


### PR DESCRIPTION
- Have constructor take `baseURI` and `MerkleRoots` since we should already know these information at the time of deployment
- Fix a bug where we have the `root` and `leaf` arguments in the wrong order when calling `MerkleProofLib.verify`
- Make `tokenType` public
- Add more tests for Web3Atl

## Test Plan
```
➜  web3atl-nft git:(Ray-changes) ✗ forge test                                
[⠆] Compiling...
No files changed, compilation skipped

Running 17 tests for test/Web3Atl.t.sol:Web3AtlTest
[PASS] testBaseURIAfterSetUp() (gas: 12388)
[PASS] testGeneralMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 48266, ~: 47300)
[PASS] testGeneralMintValidAddressAndProof() (gas: 153341)
[PASS] testHackerMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 49566, ~: 48921)
[PASS] testHackerMintValidAddressAndProof() (gas: 133614)
[PASS] testSafeTransferFrom() (gas: 130846)
[PASS] testSafeTransferFromWithCallData(bytes) (runs: 256, μ: 131422, ~: 131421)
[PASS] testSetBaseURI(string) (runs: 256, μ: 54836, ~: 62121)
[PASS] testSetBaseURINotOwner(address,string) (runs: 256, μ: 12342, ~: 12361)
[PASS] testSetMerkleRoot(bytes32,bytes32,bytes32,bytes32) (runs: 256, μ: 31600, ~: 31600)
[PASS] testSetMerkleRootNotOwner(address,bytes32,bytes32,bytes32,bytes32) (runs: 256, μ: 11404, ~: 11404)
[PASS] testSpeakerMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 48560, ~: 48715)
[PASS] testSpeakerMintValidAddressAndProof() (gas: 153430)
[PASS] testTeamMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 48030, ~: 47796)
[PASS] testTeamMintValidAddressAndProof() (gas: 153385)
[PASS] testTokenURI() (gas: 140663)
[PASS] testTransferFrom() (gas: 130813)
Test result: ok. 17 passed; 0 failed; finished in 94.50ms
➜  web3atl-nft git:(Ray-changes) ✗ 
```