### PR TITLE
Change mint function to take in email and proof

### DIFF
--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -52,8 +52,8 @@ contract Web3Atl is ERC721, Ownable {
 
     /// @notice mint function for hackathon participants
     /// @param _hackerProof merkle tree proof
-    function hackerMint(bytes32[] calldata _hackerProof) public {
-        bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
+    function hackerMint(bytes32[] calldata _hackerProof, string calldata email) public {
+        bytes32 leaf = keccak256(abi.encodePacked(email));
         require(
             MerkleProofLib.verify(_hackerProof, hackerMerkleRoot, leaf),
             "You are not a hacker"
@@ -68,8 +68,8 @@ contract Web3Atl is ERC721, Ownable {
 
     /// @notice mint function for general participants
     /// @param _generalProof merkle tree proof
-    function generalMint(bytes32[] calldata _generalProof) public {
-        bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
+    function generalMint(bytes32[] calldata _generalProof, string calldata email) public {
+        bytes32 leaf = keccak256(abi.encodePacked(email));
         require(
             MerkleProofLib.verify(_generalProof, generalMerkleRoot, leaf),
             "You are not a general attendee"
@@ -84,8 +84,8 @@ contract Web3Atl is ERC721, Ownable {
 
     /// @notice mint function for team
     /// @param _teamProof merkle tree proof
-    function teamMint(bytes32[] calldata _teamProof) public {
-        bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
+    function teamMint(bytes32[] calldata _teamProof, string calldata email) public {
+        bytes32 leaf = keccak256(abi.encodePacked(email));
         require(
             MerkleProofLib.verify(_teamProof, teamMerkleRoot, leaf),
             "You are not a team member"
@@ -100,8 +100,8 @@ contract Web3Atl is ERC721, Ownable {
 
     /// @notice mint function for speakers
     /// @param _speakerProof merkle tree proof
-    function speakerMint(bytes32[] calldata _speakerProof) public {
-        bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
+    function speakerMint(bytes32[] calldata _speakerProof, string calldata email) public {
+        bytes32 leaf = keccak256(abi.encodePacked(email));
         require(
             MerkleProofLib.verify(_speakerProof, speakerMerkleRoot, leaf),
             "You are not a speaker"

--- a/test/Web3Atl.t.sol
+++ b/test/Web3Atl.t.sol
@@ -10,10 +10,12 @@ contract Web3AtlTest is Test {
     Web3Atl public web3atl;
     string public baseURI = "http://www.google.com";
     
-    bytes32 merkleRootHacker = 0xb4fbf216f54d8076e21c170049082954cc613623e76fb5aab2acce1daeae683a;
-    bytes32 merkleRootGeneral = 0x4d3fcb52d31462529df063f8a5bd68dcca0642f9eb1c686676c8f79b8f3b2e81;
-    bytes32 merkleRootTeam = 0x1fa1b44ca84213104080ce844322b0ed53acb13304413773f6f3b23d34fbd434;
-    bytes32 merkleRootSpeaker = 0x91b8f47511578845af7aa2a841fa49dfefe81f5fa7180a9579af282f94610d44;
+    address someAddress = 0x0e77381EAeCd47696438EABaB9aF8859261837F3;
+    
+    bytes32 merkleRootHacker = 0xe209c98de34f562fcf6a03ad0eb3f404b05809e14cb40261e346b6a07c4fb58c;
+    bytes32 merkleRootGeneral = 0x602a2c5824817b54b4bb3af93c2b415bd07b7d752866cee453e6164d8d58782f;
+    bytes32 merkleRootTeam = 0x9d729cb5a147ad988999e56cdcf4c12130cb46a0f9fb243bfe274361ea78a365;
+    bytes32 merkleRootSpeaker = 0x5ba534e523999b0c7db02b8196c7c03629d9e09a711b150dd8465c8d473eec45;
 
     function setUp() public {
         web3atl = new Web3Atl('Web3Atl Attendees','W3ATL', baseURI, merkleRootHacker, merkleRootGeneral, merkleRootTeam, merkleRootSpeaker);
@@ -37,177 +39,187 @@ contract Web3AtlTest is Test {
     function testHackerMintValidAddressAndProof() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
         
-        assertEq(web3atl.tokenOwner(tokenID), hackerAddress);
+        assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.HACKER);
-        assert(web3atl.hackerClaimed(hackerAddress));
+        assert(web3atl.hackerClaimed(someAddress));
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
     }
 
     function testHackerCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
         
-        vm.prank(hackerAddress);
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.hackerMint(proof);
+        web3atl.hackerMint(proof, hackerEmail);
     }
 
     function testHackerMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);        
         vm.expectRevert();
-        web3atl.hackerMint(proof);
+        web3atl.hackerMint(proof, hackerEmail);
     }
 
     function testGeneralMintValidAddressAndProof() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x3aa681f45a864d97845dc2341b9aa2ca3ad6f4c512b6a324caf7625fe6e17ba4;
-        proof[1] = 0x3c2715b13dbf00e2e7599f4db973e15c5f22ccde8b5fbb56363b47b7b3c19307;
-        proof[2] = 0xde127622dbe22a3b21641fc6d27aaa4d4cae7cc5dd5287a81f2352d272b28d60;
-        proof[3] = 0x3361b6655670e8cd9453722e2beb88101d9f6f821620e0f051aa5fed75273aa1;
+        bytes32[] memory proof = new bytes32[](8);
+        proof[0] = 0xec647c6f58891e15912d549678bd5e3578652f7f28b9ca0fd4804ea811ed65c3;
+        proof[1] = 0xe080df37675267b4cf18786aa81d276d79f48fbd27f7de60930fd5c4de131b14;
+        proof[2] = 0x0db3cfa0a39ede66a98d6e98bd7d6229383e3b2e7d0df56fe8b0c35605c1e679;
+        proof[3] = 0x55135d1b80d3ea504dfbb70ca163de7e24a15c7cf6955a67c6ddfe238036d960;
+        proof[4] = 0xd75b7739b503840872fb1a8f61b54d0acf776fd7488306faadad3423c1a55bae;
+        proof[5] = 0x83532ef296538b0d2af36fc328f3321cd83a1a25327ee7fa272388c218182a12;
+        proof[6] = 0x0e4cc3d1ac5877f547959733b4ffb33bfaaf31708a29f566c18b5bf5ad73e30f;
+        proof[7] = 0x4ce7d45d3e8ac381a6bac7fb9acd0c61b5aba0f7addaa8ea8fc74cb4ad2bfed1;
         
-        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
-        vm.prank(generalAddress);
-        web3atl.generalMint(proof);
+        string memory generalEmail = "jasmine.guerra@ubs.com";
+        vm.prank(someAddress);
+        web3atl.generalMint(proof, generalEmail);
         
-        assertEq(web3atl.tokenOwner(tokenID), generalAddress);
+        assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.GENERAL);
-        assert(web3atl.generalClaimed(generalAddress));
+        assert(web3atl.generalClaimed(someAddress));
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
     }
 
     function testGeneralCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x3aa681f45a864d97845dc2341b9aa2ca3ad6f4c512b6a324caf7625fe6e17ba4;
-        proof[1] = 0x3c2715b13dbf00e2e7599f4db973e15c5f22ccde8b5fbb56363b47b7b3c19307;
-        proof[2] = 0xde127622dbe22a3b21641fc6d27aaa4d4cae7cc5dd5287a81f2352d272b28d60;
-        proof[3] = 0x3361b6655670e8cd9453722e2beb88101d9f6f821620e0f051aa5fed75273aa1;
+        bytes32[] memory proof = new bytes32[](8);
+        proof[0] = 0xec647c6f58891e15912d549678bd5e3578652f7f28b9ca0fd4804ea811ed65c3;
+        proof[1] = 0xe080df37675267b4cf18786aa81d276d79f48fbd27f7de60930fd5c4de131b14;
+        proof[2] = 0x0db3cfa0a39ede66a98d6e98bd7d6229383e3b2e7d0df56fe8b0c35605c1e679;
+        proof[3] = 0x55135d1b80d3ea504dfbb70ca163de7e24a15c7cf6955a67c6ddfe238036d960;
+        proof[4] = 0xd75b7739b503840872fb1a8f61b54d0acf776fd7488306faadad3423c1a55bae;
+        proof[5] = 0x83532ef296538b0d2af36fc328f3321cd83a1a25327ee7fa272388c218182a12;
+        proof[6] = 0x0e4cc3d1ac5877f547959733b4ffb33bfaaf31708a29f566c18b5bf5ad73e30f;
+        proof[7] = 0x4ce7d45d3e8ac381a6bac7fb9acd0c61b5aba0f7addaa8ea8fc74cb4ad2bfed1;
         
-        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
-        vm.prank(generalAddress);
-        web3atl.generalMint(proof);
+        string memory generalEmail = "jasmine.guerra@ubs.com";
+        vm.prank(someAddress);
+        web3atl.generalMint(proof, generalEmail);
         
-        vm.prank(generalAddress);
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.generalMint(proof);
+        web3atl.generalMint(proof, generalEmail);
     }
 
     function testGeneralMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        address generalAddress = 0x4A5f78Ebe62CcCbA6698BED7D878846ad947A513;
-        vm.prank(generalAddress);
+        string memory generalEmail = "jasmine.guerra@ubs.com";
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.generalMint(proof);
+        web3atl.generalMint(proof, generalEmail);
     }
     
     function testTeamMintValidAddressAndProof() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0xad8c33e774d72922c432a84b04cd50002dc4fd8132f2c15026badc9af139a78a;
-        proof[1] = 0x51e301f9a1a65b6bfdc6dde3abf457c998378a4c171654b8f6f4a52d921e6ba5;
-        proof[2] = 0x258f6d28136116795a2538071df3d61c3d291eb705e4cf54b559f08980a93c44;
-        proof[3] = 0x28572302ba5c6b91c6ef2a49e675f5648b0e83483903863cf7fd9f4202d0e384;
+        bytes32[] memory proof = new bytes32[](3);
+        proof[0] = 0x7edf1ec327977661b7c80286118e1333269b1b1e554167c3e804bdcb271f399b;
+        proof[1] = 0xa5a89c345e719f1ac6d052e9413caed0d43994fd902943cddadfa53e7125c0d8;
+        proof[2] = 0xd462a467848c4c38e78b641ca7ce46badb7534a3d592371ae4c406decd197b49;
         
-        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
-        vm.prank(teamAddress);
-        web3atl.teamMint(proof);
+        string memory teamEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.teamMint(proof, teamEmail);
         
-        assertEq(web3atl.tokenOwner(tokenID), teamAddress);
+        assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.TEAM);
-        assert(web3atl.teamClaimed(teamAddress));
+        assert(web3atl.teamClaimed(someAddress));
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
     }
 
     function testTeamCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0xad8c33e774d72922c432a84b04cd50002dc4fd8132f2c15026badc9af139a78a;
-        proof[1] = 0x51e301f9a1a65b6bfdc6dde3abf457c998378a4c171654b8f6f4a52d921e6ba5;
-        proof[2] = 0x258f6d28136116795a2538071df3d61c3d291eb705e4cf54b559f08980a93c44;
-        proof[3] = 0x28572302ba5c6b91c6ef2a49e675f5648b0e83483903863cf7fd9f4202d0e384;
+        bytes32[] memory proof = new bytes32[](3);
+        proof[0] = 0x7edf1ec327977661b7c80286118e1333269b1b1e554167c3e804bdcb271f399b;
+        proof[1] = 0xa5a89c345e719f1ac6d052e9413caed0d43994fd902943cddadfa53e7125c0d8;
+        proof[2] = 0xd462a467848c4c38e78b641ca7ce46badb7534a3d592371ae4c406decd197b49;
         
-        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
-        vm.prank(teamAddress);
-        web3atl.teamMint(proof);
+        string memory teamEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.teamMint(proof, teamEmail);
         
-        vm.prank(teamAddress);
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.teamMint(proof);
+        web3atl.teamMint(proof, teamEmail);
     }
 
     function testTeamMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        address teamAddress = 0xF3dD322E9548C48717Cf2c2C0DED600e4663AC64;
-        vm.prank(teamAddress);
+        string memory teamEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.teamMint(proof);
+        web3atl.teamMint(proof, teamEmail);
     }
 
     function testSpeakerMintValidAddressAndProof() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0xbc4604c224b8f02a5cb121b11860cac16d460942971558d99c3b28151ff6195c;
-        proof[1] = 0x7a03abb19f5b606aeabe37c940010ed150ce0c9d1080c847bcba06652be93d20;
-        proof[2] = 0x4c3840bc5d26b526b7859a60563e28bbeb901d087803855af0aaf00556744838;
-        proof[3] = 0x948c4f23df5e9ed19debfbb6f9493ba7a2b8cf747862149cbb4334cebb735b35;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x6d8095ce3f59631e92f67a00730529fe5a197c39f218cb515b123e79eecd501e;
+        proof[1] = 0xbd0396b2641ecc6bca35cde841f72c5a26c5dc54df377363e8fe81e31204ef83;
+        proof[2] = 0xb0ebff90280b9b8a8bbfcb465695e56adff6ee89733883d04cbc258cb5e508a1;
+        proof[3] = 0xd3e1cf1f3e618fd680b486f8c39a31d1771e4fbce33d8c1843b15bc5b724b37e;
+        proof[4] = 0x8af70561a7d6576c294ef70b523547c27256fd62a7863e99fbb9e952f5019e77;
         
-        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
-        vm.prank(speakerAddress);
-        web3atl.speakerMint(proof);
+        string memory speakerEmail = "avery.bartlett@avalabs.org";
+        vm.prank(someAddress);
+        web3atl.speakerMint(proof, speakerEmail);
         
-        assertEq(web3atl.tokenOwner(tokenID), speakerAddress);
+        assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.SPEAKER);
-        assert(web3atl.speakerClaimed(speakerAddress));
+        assert(web3atl.speakerClaimed(someAddress));
         
         uint256 newTokenID = web3atl.tokenID();
         assertEq(newTokenID - 1, tokenID);
     }
 
     function testSpeakerCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0xbc4604c224b8f02a5cb121b11860cac16d460942971558d99c3b28151ff6195c;
-        proof[1] = 0x7a03abb19f5b606aeabe37c940010ed150ce0c9d1080c847bcba06652be93d20;
-        proof[2] = 0x4c3840bc5d26b526b7859a60563e28bbeb901d087803855af0aaf00556744838;
-        proof[3] = 0x948c4f23df5e9ed19debfbb6f9493ba7a2b8cf747862149cbb4334cebb735b35;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x6d8095ce3f59631e92f67a00730529fe5a197c39f218cb515b123e79eecd501e;
+        proof[1] = 0xbd0396b2641ecc6bca35cde841f72c5a26c5dc54df377363e8fe81e31204ef83;
+        proof[2] = 0xb0ebff90280b9b8a8bbfcb465695e56adff6ee89733883d04cbc258cb5e508a1;
+        proof[3] = 0xd3e1cf1f3e618fd680b486f8c39a31d1771e4fbce33d8c1843b15bc5b724b37e;
+        proof[4] = 0x8af70561a7d6576c294ef70b523547c27256fd62a7863e99fbb9e952f5019e77;
         
-        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
-        vm.prank(speakerAddress);
-        web3atl.speakerMint(proof);
+        string memory speakerEmail = "avery.bartlett@avalabs.org";
+        vm.prank(someAddress);
+        web3atl.speakerMint(proof, speakerEmail);
         
-        vm.prank(speakerAddress);
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.speakerMint(proof);
+        web3atl.speakerMint(proof, speakerEmail);
     }
 
     function testSpeakerMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        address speakerAddress = 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf;
-        vm.prank(speakerAddress);
+        string memory speakerEmail = "avery.bartlett@avalabs.org";
+        vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.speakerMint(proof);
+        web3atl.speakerMint(proof, speakerEmail);
     }
 
     function testSetMerkleRoot(bytes32 newMerkleRootHacker, bytes32 newMerkleRootGeneral, bytes32 newMerkleRootTeam, bytes32 newMerkleRootSpeaker) public {
@@ -228,15 +240,16 @@ contract Web3AtlTest is Test {
     function testTokenURI() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
         
         assertEq(web3atl.tokenURI(tokenID), string.concat(
                 baseURI,
@@ -249,51 +262,54 @@ contract Web3AtlTest is Test {
     function testTransferFrom() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
 
         vm.expectRevert();
-        web3atl.transferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
+        web3atl.transferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
     }
 
     function testSafeTransferFrom() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
 
         vm.expectRevert();
-        web3atl.safeTransferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
+        web3atl.safeTransferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
     }
 
     function testSafeTransferFromWithCallData(bytes calldata data) public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = 0x352f9bffc6f7900ed10f105a5e8532b7d1cd1170b7b0ef8a5947abe23d0b5c80;
-        proof[1] = 0xac9dd2bb6d49a1329e0ae183b4ab51347054955da9284b22cabde012aa8ddcfa;
-        proof[2] = 0xbd8808a2894ea6811d9770eb3da1727152d2c5276d614fc3e0236e5003f3fa0f;
-        proof[3] = 0xafb35ccfcadbf2156d58ae963db52d7da26e5be560c0f08e3cefba3aa93ce6f6;
+        bytes32[] memory proof = new bytes32[](5);
+        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
+        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
+        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
+        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
+        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        address hackerAddress = 0x8C45d5DFA32B48806902cb0608Fc85C63E02F9b2;
-        vm.prank(hackerAddress);
-        web3atl.hackerMint(proof);
+        string memory hackerEmail = "pruitt.martin@gmail.com";
+        vm.prank(someAddress);
+        web3atl.hackerMint(proof, hackerEmail);
 
         vm.expectRevert();
-        web3atl.safeTransferFrom(hackerAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID, data);
+        web3atl.safeTransferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID, data);
     }
 }


### PR DESCRIPTION
Update mint functions to use user provided email as merkle root.

# Test Plan
```
➜  web3atl-nft git:(feat-mint-with-email) forge test 
[⠢] Compiling...
No files changed, compilation skipped

Running 21 tests for test/Web3Atl.t.sol:Web3AtlTest
[PASS] testBaseURIAfterSetUp() (gas: 12411)
[PASS] testGeneralCannotMintTwice() (gas: 156812)
[PASS] testGeneralMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 49514, ~: 50115)
[PASS] testGeneralMintValidAddressAndProof() (gas: 157521)
[PASS] testHackerCannotMintTwice() (gas: 135817)
[PASS] testHackerMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 48357, ~: 48073)
[PASS] testHackerMintValidAddressAndProof() (gas: 137031)
[PASS] testSafeTransferFrom() (gas: 134056)
[PASS] testSafeTransferFromWithCallData(bytes) (runs: 256, μ: 134711, ~: 134710)
[PASS] testSetBaseURI(string) (runs: 256, μ: 54659, ~: 62142)
[PASS] testSetBaseURINotOwner(address,string) (runs: 256, μ: 12287, ~: 12294)
[PASS] testSetMerkleRoot(bytes32,bytes32,bytes32,bytes32) (runs: 256, μ: 31623, ~: 31623)
[PASS] testSetMerkleRootNotOwner(address,bytes32,bytes32,bytes32,bytes32) (runs: 256, μ: 11338, ~: 11338)
[PASS] testSpeakerCannotMintTwice() (gas: 155286)
[PASS] testSpeakerMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 49659, ~: 49532)
[PASS] testSpeakerMintValidAddressAndProof() (gas: 156720)
[PASS] testTeamCannotMintTwice() (gas: 154534)
[PASS] testTeamMintInvalidAddressAndProof(bytes32[]) (runs: 256, μ: 50616, ~: 50966)
[PASS] testTeamMintValidAddressAndProof() (gas: 156206)
[PASS] testTokenURI() (gas: 142287)
[PASS] testTransferFrom() (gas: 133979)
Test result: ok. 21 passed; 0 failed; finished in 98.39ms
➜  web3atl-nft git:(feat-mint-with-email) 
```