### PR TITLE
Remove merkletree validation when mint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ out/
 
 # Dotenv file
 .env
+
+.vscode

--- a/src/Web3Atl.sol
+++ b/src/Web3Atl.sol
@@ -18,12 +18,6 @@ contract Web3Atl is ERC721, Ownable {
         SPEAKER
     }
 
-    // instantiate merkle roots for all attendee types
-    bytes32 public hackerMerkleRoot;
-    bytes32 public generalMerkleRoot;
-    bytes32 public teamMerkleRoot;
-    bytes32 public speakerMerkleRoot;
-
     // instantiate attendee type for a tokenID. Used to set uri's.
     mapping(uint256 => AttendeeTypes) public tokenType;
 
@@ -36,28 +30,13 @@ contract Web3Atl is ERC721, Ownable {
     mapping(address => bool) public teamClaimed;
     mapping(address => bool) public speakerClaimed;
 
-    constructor(
-        string memory _name,
-        string memory _symbol,
-        string memory _baseURI,
-        bytes32 _hackerMerkleRoot,
-        bytes32 _generalMerkleRoot,
-        bytes32 _teamMerkleRoot,
-        bytes32 _speakerMerkleRoot
-    ) ERC721(_name, _symbol) {
+    constructor(string memory _name, string memory _symbol, string memory _baseURI) ERC721(_name, _symbol) {
         tokenID = 0;
         baseURI = _baseURI;
-        _setMerkleRoots(_hackerMerkleRoot, _generalMerkleRoot, _teamMerkleRoot, _speakerMerkleRoot);
     }
 
     /// @notice mint function for hackathon participants
-    /// @param _hackerProof merkle tree proof
-    function hackerMint(bytes32[] calldata _hackerProof, string calldata email) public {
-        bytes32 leaf = keccak256(abi.encodePacked(email));
-        require(
-            MerkleProofLib.verify(_hackerProof, hackerMerkleRoot, leaf),
-            "You are not a hacker"
-        );
+    function hackerMint() public {
         require(!hackerClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -67,13 +46,7 @@ contract Web3Atl is ERC721, Ownable {
     }
 
     /// @notice mint function for general participants
-    /// @param _generalProof merkle tree proof
-    function generalMint(bytes32[] calldata _generalProof, string calldata email) public {
-        bytes32 leaf = keccak256(abi.encodePacked(email));
-        require(
-            MerkleProofLib.verify(_generalProof, generalMerkleRoot, leaf),
-            "You are not a general attendee"
-        );
+    function generalMint() public {
         require(!generalClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -83,13 +56,7 @@ contract Web3Atl is ERC721, Ownable {
     }
 
     /// @notice mint function for team
-    /// @param _teamProof merkle tree proof
-    function teamMint(bytes32[] calldata _teamProof, string calldata email) public {
-        bytes32 leaf = keccak256(abi.encodePacked(email));
-        require(
-            MerkleProofLib.verify(_teamProof, teamMerkleRoot, leaf),
-            "You are not a team member"
-        );
+    function teamMint() public {
         require(!teamClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
@@ -99,42 +66,13 @@ contract Web3Atl is ERC721, Ownable {
     }
 
     /// @notice mint function for speakers
-    /// @param _speakerProof merkle tree proof
-    function speakerMint(bytes32[] calldata _speakerProof, string calldata email) public {
-        bytes32 leaf = keccak256(abi.encodePacked(email));
-        require(
-            MerkleProofLib.verify(_speakerProof, speakerMerkleRoot, leaf),
-            "You are not a speaker"
-        );
+    function speakerMint() public {
         require(!speakerClaimed[msg.sender], "You already claimed your token");
         _mint(msg.sender, tokenID);
         tokenOwner[tokenID] = msg.sender;
         tokenType[tokenID] = AttendeeTypes.SPEAKER;
         speakerClaimed[msg.sender] = true;
         tokenID++;
-    }
-
-    /// @notice sets the merkle roots for all attendee types
-    function _setMerkleRoots(
-        bytes32 _hackerMerkleRoot,
-        bytes32 _generalMerkleRoot,
-        bytes32 _teamMerkleRoot,
-        bytes32 _speakerMerkleRoot
-    ) private {
-        hackerMerkleRoot = _hackerMerkleRoot;
-        generalMerkleRoot = _generalMerkleRoot;
-        teamMerkleRoot = _teamMerkleRoot;
-        speakerMerkleRoot = _speakerMerkleRoot;
-    }
-
-    /// @notice sets the merkle roots for all attendee types
-    function setMerkleRoots(
-        bytes32 _hackerMerkleRoot,
-        bytes32 _generalMerkleRoot,
-        bytes32 _teamMerkleRoot,
-        bytes32 _speakerMerkleRoot
-    ) external onlyOwner {
-        _setMerkleRoots(_hackerMerkleRoot, _generalMerkleRoot, _teamMerkleRoot, _speakerMerkleRoot);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/test/Web3Atl.t.sol
+++ b/test/Web3Atl.t.sol
@@ -11,14 +11,9 @@ contract Web3AtlTest is Test {
     string public baseURI = "http://www.google.com";
     
     address someAddress = 0x0e77381EAeCd47696438EABaB9aF8859261837F3;
-    
-    bytes32 merkleRootHacker = 0xe209c98de34f562fcf6a03ad0eb3f404b05809e14cb40261e346b6a07c4fb58c;
-    bytes32 merkleRootGeneral = 0x602a2c5824817b54b4bb3af93c2b415bd07b7d752866cee453e6164d8d58782f;
-    bytes32 merkleRootTeam = 0x9d729cb5a147ad988999e56cdcf4c12130cb46a0f9fb243bfe274361ea78a365;
-    bytes32 merkleRootSpeaker = 0x5ba534e523999b0c7db02b8196c7c03629d9e09a711b150dd8465c8d473eec45;
 
     function setUp() public {
-        web3atl = new Web3Atl('Web3Atl Attendees','W3ATL', baseURI, merkleRootHacker, merkleRootGeneral, merkleRootTeam, merkleRootSpeaker);
+        web3atl = new Web3Atl('Web3Atl Attendees','W3ATL', baseURI);
     }
 
     function testBaseURIAfterSetUp() public {
@@ -36,19 +31,11 @@ contract Web3AtlTest is Test {
         web3atl.setBaseURI(newBaseURI);
     }
 
-    function testHackerMintValidAddressAndProof() public {
+    function testHackerMint() public {
         uint256 tokenID = web3atl.tokenID();
-
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
         
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
         
         assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.HACKER);
@@ -59,45 +46,19 @@ contract Web3AtlTest is Test {
     }
 
     function testHackerCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
-        
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
         
         vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
     }
 
-    function testHackerMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        string memory hackerEmail = "pruitt.martin@gmail.com";
-        vm.prank(someAddress);        
-        vm.expectRevert();
-        web3atl.hackerMint(proof, hackerEmail);
-    }
-
-    function testGeneralMintValidAddressAndProof() public {
+    function testGeneralMint() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](8);
-        proof[0] = 0xec647c6f58891e15912d549678bd5e3578652f7f28b9ca0fd4804ea811ed65c3;
-        proof[1] = 0xe080df37675267b4cf18786aa81d276d79f48fbd27f7de60930fd5c4de131b14;
-        proof[2] = 0x0db3cfa0a39ede66a98d6e98bd7d6229383e3b2e7d0df56fe8b0c35605c1e679;
-        proof[3] = 0x55135d1b80d3ea504dfbb70ca163de7e24a15c7cf6955a67c6ddfe238036d960;
-        proof[4] = 0xd75b7739b503840872fb1a8f61b54d0acf776fd7488306faadad3423c1a55bae;
-        proof[5] = 0x83532ef296538b0d2af36fc328f3321cd83a1a25327ee7fa272388c218182a12;
-        proof[6] = 0x0e4cc3d1ac5877f547959733b4ffb33bfaaf31708a29f566c18b5bf5ad73e30f;
-        proof[7] = 0x4ce7d45d3e8ac381a6bac7fb9acd0c61b5aba0f7addaa8ea8fc74cb4ad2bfed1;
-        
-        string memory generalEmail = "jasmine.guerra@ubs.com";
         vm.prank(someAddress);
-        web3atl.generalMint(proof, generalEmail);
+        web3atl.generalMint();
         
         assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.GENERAL);
@@ -108,43 +69,19 @@ contract Web3AtlTest is Test {
     }
 
     function testGeneralCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](8);
-        proof[0] = 0xec647c6f58891e15912d549678bd5e3578652f7f28b9ca0fd4804ea811ed65c3;
-        proof[1] = 0xe080df37675267b4cf18786aa81d276d79f48fbd27f7de60930fd5c4de131b14;
-        proof[2] = 0x0db3cfa0a39ede66a98d6e98bd7d6229383e3b2e7d0df56fe8b0c35605c1e679;
-        proof[3] = 0x55135d1b80d3ea504dfbb70ca163de7e24a15c7cf6955a67c6ddfe238036d960;
-        proof[4] = 0xd75b7739b503840872fb1a8f61b54d0acf776fd7488306faadad3423c1a55bae;
-        proof[5] = 0x83532ef296538b0d2af36fc328f3321cd83a1a25327ee7fa272388c218182a12;
-        proof[6] = 0x0e4cc3d1ac5877f547959733b4ffb33bfaaf31708a29f566c18b5bf5ad73e30f;
-        proof[7] = 0x4ce7d45d3e8ac381a6bac7fb9acd0c61b5aba0f7addaa8ea8fc74cb4ad2bfed1;
-        
-        string memory generalEmail = "jasmine.guerra@ubs.com";
         vm.prank(someAddress);
-        web3atl.generalMint(proof, generalEmail);
+        web3atl.generalMint();
         
         vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.generalMint(proof, generalEmail);
-    }
-
-    function testGeneralMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        string memory generalEmail = "jasmine.guerra@ubs.com";
-        vm.prank(someAddress);
-        vm.expectRevert();
-        web3atl.generalMint(proof, generalEmail);
+        web3atl.generalMint();
     }
     
-    function testTeamMintValidAddressAndProof() public {
+    function testTeamMint() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](3);
-        proof[0] = 0x7edf1ec327977661b7c80286118e1333269b1b1e554167c3e804bdcb271f399b;
-        proof[1] = 0xa5a89c345e719f1ac6d052e9413caed0d43994fd902943cddadfa53e7125c0d8;
-        proof[2] = 0xd462a467848c4c38e78b641ca7ce46badb7534a3d592371ae4c406decd197b49;
-        
-        string memory teamEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.teamMint(proof, teamEmail);
+        web3atl.teamMint();
         
         assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.TEAM);
@@ -155,40 +92,19 @@ contract Web3AtlTest is Test {
     }
 
     function testTeamCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](3);
-        proof[0] = 0x7edf1ec327977661b7c80286118e1333269b1b1e554167c3e804bdcb271f399b;
-        proof[1] = 0xa5a89c345e719f1ac6d052e9413caed0d43994fd902943cddadfa53e7125c0d8;
-        proof[2] = 0xd462a467848c4c38e78b641ca7ce46badb7534a3d592371ae4c406decd197b49;
-        
-        string memory teamEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.teamMint(proof, teamEmail);
+        web3atl.teamMint();
         
         vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.teamMint(proof, teamEmail);
+        web3atl.teamMint();
     }
 
-    function testTeamMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        string memory teamEmail = "pruitt.martin@gmail.com";
-        vm.prank(someAddress);
-        vm.expectRevert();
-        web3atl.teamMint(proof, teamEmail);
-    }
-
-    function testSpeakerMintValidAddressAndProof() public {
+    function testSpeakerMint() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x6d8095ce3f59631e92f67a00730529fe5a197c39f218cb515b123e79eecd501e;
-        proof[1] = 0xbd0396b2641ecc6bca35cde841f72c5a26c5dc54df377363e8fe81e31204ef83;
-        proof[2] = 0xb0ebff90280b9b8a8bbfcb465695e56adff6ee89733883d04cbc258cb5e508a1;
-        proof[3] = 0xd3e1cf1f3e618fd680b486f8c39a31d1771e4fbce33d8c1843b15bc5b724b37e;
-        proof[4] = 0x8af70561a7d6576c294ef70b523547c27256fd62a7863e99fbb9e952f5019e77;
-        
-        string memory speakerEmail = "avery.bartlett@avalabs.org";
         vm.prank(someAddress);
-        web3atl.speakerMint(proof, speakerEmail);
+        web3atl.speakerMint();
         
         assertEq(web3atl.tokenOwner(tokenID), someAddress);
         assert(web3atl.tokenType(tokenID) == Web3Atl.AttendeeTypes.SPEAKER);
@@ -199,57 +115,19 @@ contract Web3AtlTest is Test {
     }
 
     function testSpeakerCannotMintTwice() public {
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x6d8095ce3f59631e92f67a00730529fe5a197c39f218cb515b123e79eecd501e;
-        proof[1] = 0xbd0396b2641ecc6bca35cde841f72c5a26c5dc54df377363e8fe81e31204ef83;
-        proof[2] = 0xb0ebff90280b9b8a8bbfcb465695e56adff6ee89733883d04cbc258cb5e508a1;
-        proof[3] = 0xd3e1cf1f3e618fd680b486f8c39a31d1771e4fbce33d8c1843b15bc5b724b37e;
-        proof[4] = 0x8af70561a7d6576c294ef70b523547c27256fd62a7863e99fbb9e952f5019e77;
-        
-        string memory speakerEmail = "avery.bartlett@avalabs.org";
         vm.prank(someAddress);
-        web3atl.speakerMint(proof, speakerEmail);
+        web3atl.speakerMint();
         
         vm.prank(someAddress);
         vm.expectRevert();
-        web3atl.speakerMint(proof, speakerEmail);
-    }
-
-    function testSpeakerMintInvalidAddressAndProof(bytes32[] memory proof) public {
-        string memory speakerEmail = "avery.bartlett@avalabs.org";
-        vm.prank(someAddress);
-        vm.expectRevert();
-        web3atl.speakerMint(proof, speakerEmail);
-    }
-
-    function testSetMerkleRoot(bytes32 newMerkleRootHacker, bytes32 newMerkleRootGeneral, bytes32 newMerkleRootTeam, bytes32 newMerkleRootSpeaker) public {
-        web3atl.setMerkleRoots(newMerkleRootHacker, newMerkleRootGeneral, newMerkleRootTeam, newMerkleRootSpeaker);
-
-        assertEq(web3atl.hackerMerkleRoot(), newMerkleRootHacker);
-        assertEq(web3atl.generalMerkleRoot(), newMerkleRootGeneral);
-        assertEq(web3atl.teamMerkleRoot(), newMerkleRootTeam);
-        assertEq(web3atl.speakerMerkleRoot(), newMerkleRootSpeaker);
-    }
-
-    function testSetMerkleRootNotOwner(address addr, bytes32 newMerkleRootHacker, bytes32 newMerkleRootGeneral, bytes32 newMerkleRootTeam, bytes32 newMerkleRootSpeaker) public {
-        vm.prank(addr);
-        vm.expectRevert();
-        web3atl.setMerkleRoots(newMerkleRootHacker, newMerkleRootGeneral, newMerkleRootTeam, newMerkleRootSpeaker);
+        web3atl.speakerMint();
     }
 
     function testTokenURI() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
-        
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
         
         assertEq(web3atl.tokenURI(tokenID), string.concat(
                 baseURI,
@@ -262,16 +140,8 @@ contract Web3AtlTest is Test {
     function testTransferFrom() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
-        
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
 
         vm.expectRevert();
         web3atl.transferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
@@ -280,16 +150,8 @@ contract Web3AtlTest is Test {
     function testSafeTransferFrom() public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
-        
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
 
         vm.expectRevert();
         web3atl.safeTransferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID);
@@ -298,16 +160,8 @@ contract Web3AtlTest is Test {
     function testSafeTransferFromWithCallData(bytes calldata data) public {
         uint256 tokenID = web3atl.tokenID();
 
-        bytes32[] memory proof = new bytes32[](5);
-        proof[0] = 0x50369893b33d1ad37b6e4a41be5f647a503359518db68cb8e6deaa02e43f2fe0;
-        proof[1] = 0xf30ebc7cb7cdcd4468f114f867f8f0c1c06d7e7dc172e81ce4ae6eec22d63b3a;
-        proof[2] = 0xec1f40956f5e1b66547f2464364e01413313e2c8ad828efbca161bf7345155fa;
-        proof[3] = 0x3378a238ae1e143c6969099cc332304451a081a15a9cc7c0d9c11e705132e925;
-        proof[4] = 0xc0e295859558218b2cc02b52ac49d0c599e689753b0f123bb6355b76095a854f;
-        
-        string memory hackerEmail = "pruitt.martin@gmail.com";
         vm.prank(someAddress);
-        web3atl.hackerMint(proof, hackerEmail);
+        web3atl.hackerMint();
 
         vm.expectRevert();
         web3atl.safeTransferFrom(someAddress, 0xEBA5a8e3DcB4CFEFD3a3CBd420786eB6E6b1aDCf, tokenID, data);


### PR DESCRIPTION
## Test Plan

```
➜  web3atl-nft git:(fix-remove-merkletree-valiation) forge test
[⠢] Compiling...
No files changed, compilation skipped

Running 15 tests for test/Web3Atl.t.sol:Web3AtlTest
[PASS] testBaseURIAfterSetUp() (gas: 12411)
[PASS] testGeneralCannotMintTwice() (gas: 148269)
[PASS] testGeneralMint() (gas: 151814)
[PASS] testHackerCannotMintTwice() (gas: 128325)
[PASS] testHackerMint() (gas: 131844)
[PASS] testSafeTransferFrom() (gas: 128805)
[PASS] testSafeTransferFromWithCallData(bytes) (runs: 256, μ: 129510, ~: 129509)
[PASS] testSetBaseURI(string) (runs: 256, μ: 52344, ~: 62121)
[PASS] testSetBaseURINotOwner(address,string) (runs: 256, μ: 12328, ~: 12339)
[PASS] testSpeakerCannotMintTwice() (gas: 148250)
[PASS] testSpeakerMint() (gas: 151860)
[PASS] testTeamCannotMintTwice() (gas: 148269)
[PASS] testTeamMint() (gas: 151814)
[PASS] testTokenURI() (gas: 137167)
[PASS] testTransferFrom() (gas: 128794)
Test result: ok. 15 passed; 0 failed; finished in 15.20ms
➜  web3atl-nft git:(fix-remove-merkletree-valiation) 
```